### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "EllipsisNotation"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "1.8.1"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
 
 [compat]
 Aqua = "0.8"
+ExplicitImports = "1.6"
 SafeTestsets = "0.1"
 StaticArrayInterface = "1.2"
 Test = "1"
@@ -15,8 +16,9 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "SafeTestsets"]
+test = ["Aqua", "ExplicitImports", "Test", "SafeTestsets"]

--- a/src/EllipsisNotation.jl
+++ b/src/EllipsisNotation.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module EllipsisNotation
 
-using StaticArrayInterface
+using StaticArrayInterface: StaticArrayInterface
 
 import Base: to_indices, tail
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,5 +1,7 @@
+using Test
+using Test: detect_ambiguities
 using EllipsisNotation
-using StaticArrayInterface
+using StaticArrayInterface: StaticArrayInterface
 @test isempty(detect_ambiguities(EllipsisNotation))
 
 A = Array{Int}(undef, 2, 4, 2)

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -1,3 +1,4 @@
+using Test
 using EllipsisNotation
 @testset "CartesianIndex" begin
     A = rand(4, 4, 4, 4, 4)

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using EllipsisNotation
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(EllipsisNotation) === nothing
+    @test check_no_stale_explicit_imports(EllipsisNotation) === nothing
+end

--- a/test/more_generic.jl
+++ b/test/more_generic.jl
@@ -1,3 +1,4 @@
+using Test
 using EllipsisNotation
 B = Array{Int}(undef, 2, 3, 4, 5, 6)
 

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,3 +1,4 @@
+using Test
 using EllipsisNotation, Aqua
 @testset "Aqua" begin
     Aqua.find_persistent_tasks_deps(EllipsisNotation)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SafeTestsets
 
 @time @safetestset "Quality Assurance" include("qa.jl")
+@time @safetestset "Explicit Imports" include("explicit_imports.jl")
 @time @safetestset "Basic Tests" include("basic.jl")
 @time @safetestset "Generic Tests" include("more_generic.jl")
 @time @safetestset "Cartesian Tests" include("cartesian.jl")


### PR DESCRIPTION
## Summary

- Fix implicit import in main module: use `using StaticArrayInterface: StaticArrayInterface` instead of `using StaticArrayInterface` to explicitly import the module name
- Add explicit `using Test` to all test files since they are run in isolated SafeTestsets environments
- Add ExplicitImports.jl test suite to CI to prevent import hygiene regression

## Files Changed

**Source:**
- `src/EllipsisNotation.jl`: Fixed implicit import of `StaticArrayInterface`

**Tests:**
- `test/qa.jl`: Added `using Test`
- `test/basic.jl`: Added `using Test`, `using Test: detect_ambiguities`, `using StaticArrayInterface: StaticArrayInterface`
- `test/cartesian.jl`: Added `using Test`
- `test/more_generic.jl`: Added `using Test`
- `test/runtests.jl`: Added ExplicitImports test suite
- `test/explicit_imports.jl`: New test file for import hygiene checks

**Config:**
- `Project.toml`: Added ExplicitImports as test dependency

## Test plan

- [x] Ran `Pkg.test()` locally - all tests pass
- [x] Verified `check_no_implicit_imports(EllipsisNotation)` passes
- [x] Verified `check_no_stale_explicit_imports(EllipsisNotation)` passes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)