### PR TITLE
Move AllocCheck tests to nopre group only

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,6 @@ using SafeTestsets
 @time @safetestset "Generic Tests" include("more_generic.jl")
 @time @safetestset "Cartesian Tests" include("cartesian.jl")
 
-if get(ENV, "GROUP", "all") == "all" || get(ENV, "GROUP", "all") == "nopre"
+if get(ENV, "GROUP", "all") == "nopre"
     @time @safetestset "Allocation Tests" include("alloc_tests.jl")
 end


### PR DESCRIPTION
## Summary

Follow-up to PR #88 per @ChrisRackauckas's feedback.

Move AllocCheck tests to only run in the `nopre` group (`GROUP=nopre`) to avoid conflicts with precompilation testing. The tests will no longer run by default during normal `Pkg.test()`, only when explicitly requested via `GROUP=nopre`.

## Changes

Changed from:
```julia
if get(ENV, "GROUP", "all") == "all" || get(ENV, "GROUP", "all") == "nopre"
```

To:
```julia
if get(ENV, "GROUP", "all") == "nopre"
```

## Test plan
- [x] Verified tests pass with `GROUP=nopre julia -e 'using Pkg; Pkg.test()'`
- [x] Verified normal tests pass without the allocation tests

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)