### PR TITLE
Add explicit precompile statements for TTFX improvement

### DIFF
--- a/src/EllipsisNotation.jl
+++ b/src/EllipsisNotation.jl
@@ -115,6 +115,44 @@ export ..
         C4[.., 1]
         C4[1, ..]
     end
+
+    # Explicit precompile statements to force native code caching
+    # These are needed because getindex/setindex!/to_indices are Base methods
+    # and their specializations may not be cached in the package image otherwise
+
+    # Common getindex patterns
+    for T in (Float64, Float32, Int)
+        # 2D
+        precompile(getindex, (Array{T, 2}, Ellipsis, Int))
+        precompile(getindex, (Array{T, 2}, Int, Ellipsis))
+
+        # 3D - most common use case
+        precompile(getindex, (Array{T, 3}, Ellipsis, Int))
+        precompile(getindex, (Array{T, 3}, Int, Ellipsis))
+        precompile(getindex, (Array{T, 3}, Colon, Ellipsis, Int))
+        precompile(getindex, (Array{T, 3}, Int, Ellipsis, Int))
+
+        # 4D
+        precompile(getindex, (Array{T, 4}, Ellipsis, Int))
+        precompile(getindex, (Array{T, 4}, Int, Ellipsis))
+        precompile(getindex, (Array{T, 4}, Ellipsis, Int, Int))
+        precompile(getindex, (Array{T, 4}, Int, Int, Ellipsis))
+
+        # 5D
+        precompile(getindex, (Array{T, 5}, Ellipsis, Int))
+        precompile(getindex, (Array{T, 5}, Int, Ellipsis))
+    end
+
+    # Common setindex! patterns
+    for T in (Float64, Float32, Int)
+        # 3D
+        precompile(setindex!, (Array{T, 3}, Array{T, 2}, Ellipsis, Int))
+        precompile(setindex!, (Array{T, 3}, Array{T, 2}, Int, Ellipsis))
+
+        # 4D
+        precompile(setindex!, (Array{T, 4}, Array{T, 3}, Ellipsis, Int))
+        precompile(setindex!, (Array{T, 4}, Array{T, 3}, Int, Ellipsis))
+    end
 end
 
 end # module


### PR DESCRIPTION
## Summary

- Added explicit `precompile()` statements for common indexing patterns
- This dramatically improves time-to-first-X (TTFX) by caching native code for Base methods like `getindex`/`setindex!`

## Problem

The existing `@compile_workload` block runs inference during precompilation but doesn't effectively cache native code for Base methods like `getindex`/`setindex!`/`to_indices`. This is because Julia's pkgimage caching only caches native code for methods "owned" by the package being compiled.

When users call `A[.., 1]`, the `getindex` method belongs to Base, so even though inference was done during precompilation, the native code wasn't cached in EllipsisNotation's pkgimage.

## Solution

By adding explicit `precompile()` statements for common indexing patterns, we force native code generation for these signatures during package precompilation.

## Benchmark Results

### Before (first call after `using EllipsisNotation`):
| Operation | Time | Notes |
|-----------|------|-------|
| `A3[.., 1]` | 6.17 ms | 99% compilation |
| `A3[:, .., 1]` | **52.16 ms** | 99% compilation |
| `A3[1, .., 2]` | 22.35 ms | 99% compilation |

### After:
| Operation | Time | Notes |
|-----------|------|-------|
| `A3[.., 1]` | 0.07 ms | No compilation |
| `A3[:, .., 1]` | **0.08 ms** | No compilation |
| `A3[1, .., 2]` | 0.07 ms | No compilation |

This represents a **~700x improvement** for the worst case pattern (`[:, .., 1]`).

## Test plan

- [x] All existing tests pass (`Pkg.test()`)
- [x] Verified TTFX improvement with fresh precompilation
- [x] Tested with Float64, Float32, and Int arrays
- [x] Tested with 2D, 3D, 4D, and 5D arrays

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)