### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,12 +2,16 @@ using Documenter, EllipsisNotation
 
 include("pages.jl")
 
-makedocs(sitename = "EllipsisNotation.jl",
+makedocs(
+    sitename = "EllipsisNotation.jl",
     authors = "Chris Rackauckas",
     modules = [EllipsisNotation],
     clean = true, doctest = false, linkcheck = true,
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/EllipsisNotation/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/EllipsisNotation/stable/"
+    ),
+    pages = pages
+)
 
 deploydocs(repo = "github.com/SciML/EllipsisNotation.jl.git"; push_preview = true)

--- a/src/EllipsisNotation.jl
+++ b/src/EllipsisNotation.jl
@@ -49,23 +49,25 @@ true
 """
 const .. = Ellipsis()
 
-@inline function to_indices(A,
+@inline function to_indices(
+        A,
         inds::NTuple{M, Any},
-        I::Tuple{Ellipsis, Vararg{Any, N}}) where {M, N}
+        I::Tuple{Ellipsis, Vararg{Any, N}}
+    ) where {M, N}
     # Align the remaining indices to the tail of the `inds`
     colons = ntuple(n -> Colon(), M - _ndims_index(I) + 1)
-    to_indices(A, inds, (colons..., tail(I)...))
+    return to_indices(A, inds, (colons..., tail(I)...))
 end
 
 @inline _ndims_index(inds::Tuple{}) = StaticArrayInterface.static(0)
 @inline function _ndims_index(inds::Tuple)
-    StaticArrayInterface.ndims_index(inds[1]) + _ndims_index(tail(inds))
+    return StaticArrayInterface.ndims_index(inds[1]) + _ndims_index(tail(inds))
 end
 
 StaticArrayInterface.is_splat_index(::Type{Ellipsis}) = StaticArrayInterface.static(true)
 StaticArrayInterface.ndims_index(::Type{Ellipsis}) = StaticArrayInterface.static(1)
 function StaticArrayInterface.to_index(x, ::Ellipsis)
-    ntuple(i -> StaticArrayInterface.indices(x, i), Val(ndims(x)))
+    return ntuple(i -> StaticArrayInterface.indices(x, i), Val(ndims(x)))
 end
 
 export ..

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -6,35 +6,53 @@ using StaticArrayInterface: StaticArrayInterface
 
 A = Array{Int}(undef, 2, 4, 2)
 
-A[.., 1] = [2 1 4 5
-            2 2 3 6]
+A[.., 1] = [
+    2 1 4 5
+    2 2 3 6
+]
 
-A[.., 2] = [3 2 6 5
-            3 2 6 6]
+A[.., 2] = [
+    3 2 6 5
+    3 2 6 6
+]
 
-@test A[:, :, 1] == [2 1 4 5
-                     2 2 3 6]
+@test A[:, :, 1] == [
+    2 1 4 5
+    2 2 3 6
+]
 
-@test A[:, :, 2] == [3 2 6 5
-                     3 2 6 6]
+@test A[:, :, 2] == [
+    3 2 6 5
+    3 2 6 6
+]
 
-@test A[:, .., 1] == [2 1 4 5
-                      2 2 3 6]
+@test A[:, .., 1] == [
+    2 1 4 5
+    2 2 3 6
+]
 
-@test A[:, .., 1] == [2 1 4 5
-                      2 2 3 6]
+@test A[:, .., 1] == [
+    2 1 4 5
+    2 2 3 6
+]
 
-A[1, ..] = reshape([3 4
-                    5 6
-                    4 5
-                    6 7],
+A[1, ..] = reshape(
+    [
+        3 4
+        5 6
+        4 5
+        6 7
+    ],
     4,
-    2)
+    2
+)
 
-B = [3 4
-     5 6
-     4 5
-     6 7]
+B = [
+    3 4
+    5 6
+    4 5
+    6 7
+]
 
 @test B == reshape(A[1, ..], 4, 2) == reshape(view(A, 1, ..), 4, 2)
 
@@ -73,22 +91,24 @@ C[1, 1] += 1
     StaticArrayInterface.setindex!(A, [2 1 4 5; 2 2 3 6], .., 1)
     StaticArrayInterface.setindex!(A, [3 2 6 5; 3 2 6 6], .., 2)
 
-    @test StaticArrayInterface.getindex(A,:,:,1) == [2 1 4 5; 2 2 3 6]
-    @test StaticArrayInterface.getindex(A,:,:,2) == [3 2 6 5; 3 2 6 6]
+    @test StaticArrayInterface.getindex(A, :, :, 1) == [2 1 4 5; 2 2 3 6]
+    @test StaticArrayInterface.getindex(A, :, :, 2) == [3 2 6 5; 3 2 6 6]
 
-    @test StaticArrayInterface.getindex(A,:,..,1) == [2 1 4 5; 2 2 3 6]
-    @test StaticArrayInterface.getindex(A,:,..,2) == [3 2 6 5; 3 2 6 6]
+    @test StaticArrayInterface.getindex(A, :, .., 1) == [2 1 4 5; 2 2 3 6]
+    @test StaticArrayInterface.getindex(A, :, .., 2) == [3 2 6 5; 3 2 6 6]
 
     StaticArrayInterface.setindex!(A, reshape([3 4; 5 6; 4 5; 6 7], 4, 2), 1, ..)
 
-    B = [3 4
-         5 6
-         4 5
-         6 7]
+    B = [
+        3 4
+        5 6
+        4 5
+        6 7
+    ]
 
     @test B ==
-          reshape(StaticArrayInterface.getindex(A, 1, ..), 4, 2) ==
-          reshape(view(A, 1, ..), 4, 2)
+        reshape(StaticArrayInterface.getindex(A, 1, ..), 4, 2) ==
+        reshape(view(A, 1, ..), 4, 2)
 
     @test A[:, 1, 2] == StaticArrayInterface.getindex(A, .., 1, 2)
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)