### PR TITLE
Version bump to 1.9.0 - Fix failed v1.8.1 registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EllipsisNotation"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.8.1"
+version = "1.9.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Version Bump: 1.8.0 → 1.9.0

This PR fixes the failed registration of v1.8.1 by bumping to v1.9.0 instead.

### Why 1.9.0 instead of 1.8.1?

The previous registration attempt for v1.8.1 failed AutoMerge guidelines:
- **Issue**: A patch release narrowed Julia version support from 1.6+ to 1.10+
- **Failed PR**: https://github.com/JuliaRegistries/General/pull/138040
- **Resolution**: This breaking change requires a minor version bump per Julia registry guidelines

### Changes since v1.8.0 (70 commits)

**CI/Infrastructure:**
- Bump actions/checkout from 4 to 6 (#98)
- Switch from JuliaFormatter to Runic.jl for code formatting (#97)
- Migrate from CompatHelper to Dependabot (#87)
- Update CI to use reusable workflows (#78)
- Add `.typos.toml` configuration for spellcheck (#82)

**Performance & Quality:**
- Add PrecompileTools for improved TTFX (#96, #93)
- Add JET.jl static analysis tests (#94)
- Add AllocCheck tests to prevent allocation regressions (#88)
- Improve explicit imports hygiene (#89)

**Testing:**
- Testing overhaul with better organization (#69)
- Add Aqua.jl quality assurance tests (#65)
- Add Downgrade CI (#67)

**Maintenance:**
- Bump Julia minimum version to 1.10 (#68)
- Update StaticArrayInterface compat to 1.2

### Registration Commands

After merging, register with:

```
@JuliaRegistrator register
```

cc @ChrisRackauckas