### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
+      - "/test/jet"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,27 +11,13 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled pending PrecompileTools minimum version update
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group:
-          - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "Core"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary

Converts the remaining inline CI checks to the centralized SciML reusable workflows (pinned `@v1`, each caller gets `secrets: "inherit"`).

### Converted (inline -> central caller)
- **Runic** (`FormatCheck.yml`): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck** (`SpellCheck.yml`): inline `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade** (`Downgrade.yml`): inline -> `downgrade.yml@v1`, preserving `julia-version: 1.10`, `group: Core`, `skip: Pkg,TOML`, `allow-reresolve: false`, and the existing `if: false` disable (pending PrecompileTools minimum version update)

### Already central (unchanged)
- **Tests** (`Tests.yml`): already `tests.yml@v1`, matrix version=[1,lts,pre] x os=[ubuntu,macos,windows] preserved
- **Documentation** (`Documentation.yml`): already `documentation.yml@v1`

### Left inline
- **JET** (`JET.yml`): no centralized `jet.yml` equivalent exists; left unchanged.
- **TagBot**: unchanged.

### Cleanup
- `dependabot.yml`: removed the `crate-ci/typos` ignore (no longer needed; typos is now centrally managed); scoped the `julia` ecosystem to dirs that actually have a `Project.toml` (`/`, `/docs`, `/test/jet` — `/test` has none, deps live in the root `[extras]`/`[targets]`).
- No `CompatHelper.yml` present.

### Formatting / spelling
- Runic: ran `Runic.main(["--inplace","."])` locally — no changes (already clean).
- typos: ran `typos -w .` then `typos .` (exit 0) — 0 fixes needed; `.typos.toml` already covers domain words.

### Heads up
Check job names change (e.g. the Runic/SpellCheck/Downgrade jobs now run under the reusable workflow), so any branch-protection **required status checks** may need updating to match the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)