### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,7 +15,6 @@ jobs:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
+      julia-version: "lts"
       group: "Core"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
 jobs:
-  TagBot:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup.

- **TagBot.yml**: replaced the inlined `JuliaRegistries/TagBot@v1` job (permissions + steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (single-package form; this repo is not a monorepo).
- **Downgrade.yml**: dropped the `skip:` input (it only listed stdlibs `Pkg,TOML`, now auto-populated by the central workflow) and changed `julia-version: "1.10"` to `"lts"`.
Static-validated: edited YAML parses and the TOML parses.

Ignore until reviewed by @ChrisRackauckas.