### PR TITLE
QA: restore Aqua deps_compat (add missing [compat] for test extras)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
 
 [compat]
 AllocCheck = "0.2"
+Pkg = "1"
 PrecompileTools = "1.0.1"
 SafeTestsets = "0.1"
 StaticArrayInterface = "1.2.1"

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -3,10 +3,7 @@ using EllipsisNotation, Aqua
 @testset "Aqua" begin
     Aqua.find_persistent_tasks_deps(EllipsisNotation)
     Aqua.test_ambiguities(EllipsisNotation, recursive = false)
-    Aqua.test_deps_compat(EllipsisNotation, check_extras = false)
-    # Aqua deps_compat extras check: `Pkg` is in [extras]/[targets].test without a [compat] entry.
-    # Tracked in https://github.com/SciML/EllipsisNotation.jl/issues/113
-    @test_broken false
+    Aqua.test_deps_compat(EllipsisNotation)
     Aqua.test_piracies(EllipsisNotation)
     Aqua.test_project_extras(EllipsisNotation)
     Aqua.test_stale_deps(EllipsisNotation)


### PR DESCRIPTION
## Problem

The grouped-tests CI conversion added `Pkg` to `[extras]`/`[targets].test` in the package `Project.toml` without a corresponding `[compat]` entry. This trips Aqua's `test_deps_compat` extras sub-check.

The conversion worked around this by **weakening the check** rather than fixing the metadata: `Aqua.test_deps_compat(EllipsisNotation, check_extras = false)` plus a `@test_broken false` sentinel, with a tracking issue (#113).

## Fix (metadata only, one-line)

1. Add the missing `Pkg = "1"` to `[compat]` in the root `Project.toml`.
2. Restore the full `Aqua.test_deps_compat(EllipsisNotation)` call in `test/qa.jl` and remove the `check_extras = false` weakening + `@test_broken false` sentinel.

This is CI-hygiene (metadata + re-enabling a check), not a test-logic change.

## Local verification

`GROUP=QA julia +1.11 ... Pkg.test()` passes:

```
Quality Assurance |   10     10  27.3s
Explicit Imports  |    2      2
JET               |   14     14
Testing EllipsisNotation tests passed
```

Closes #113 (that issue covered only this deps_compat nit).

Ignore until reviewed by @ChrisRackauckas.