### PR TITLE
Fix Downgrade CI: raise PrecompileTools compat floor to 1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EllipsisNotation"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.10.0"
+version = "1.10.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -14,7 +14,7 @@ EllipsisNotationStaticArrayInterfaceExt = "StaticArrayInterface"
 
 [compat]
 AllocCheck = "0.2"
-PrecompileTools = "1.0.1"
+PrecompileTools = "1.1"
 SafeTestsets = "0.1"
 SciMLTesting = "1"
 StaticArrayInterface = "1.4.1"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Problem

The `Downgrade / Downgrade Tests - Core` lane on `master` is red. The error:

```
ERROR: LoadError: UndefVarError: `@recompile_invalidations` not defined
in expression starting at .../StaticArrayInterface/qmd3i/src/StaticArrayInterface.jl:19
Failed to precompile StaticArrayInterface ...
Failed to precompile EllipsisNotationStaticArrayInterfaceExt ...
Core/static_array_interface.jl | Error 1 / Total 1
```

## Root cause

The downgrade run pins direct deps to their `[compat]` floor. EllipsisNotation had `PrecompileTools = "1.0.1"`. With PrecompileTools pinned at 1.0.1, the resolver pairs it with `StaticArrayInterface v1.10.0` (every registry version of StaticArrayInterface, 1.4.1 through 1.10.0, declares `PrecompileTools = "1"`, so the latest is chosen).

Every one of those StaticArrayInterface versions does:

```julia
using PrecompileTools
@recompile_invalidations begin
    ...
end
```

but `@recompile_invalidations` was only **added to PrecompileTools in 1.1.0**. So under the downgrade resolution StaticArrayInterface fails to precompile with `UndefVarError: @recompile_invalidations not defined`, which cascades into `EllipsisNotationStaticArrayInterfaceExt` and the `static_array_interface.jl` Core test.

StaticArrayInterface advertising `PrecompileTools = "1"` is itself too loose (upstream bug), but EllipsisNotation can avoid the bad pairing by requiring `PrecompileTools >= 1.1`, where the macro exists.

## Fix

Raise `PrecompileTools` compat floor `1.0.1 -> 1.1`, and bump the package version `1.10.0 -> 1.10.1` (compat change requires a release for registration).

## Verification (local, Julia LTS 1.10.11)

Reproduced the exact failure before the fix (PrecompileTools pinned 1.0.1):

```
✗ Static
✗ StaticArrayInterface
✗ EllipsisNotation → EllipsisNotationStaticArrayInterfaceExt
UndefVarError: `@recompile_invalidations` not defined
```

After the fix (PrecompileTools pinned at the new floor 1.1.0, StaticArrayInterface v1.10.0 resolved):

```
✓ EllipsisNotation
✓ StaticArrayInterface
✓ EllipsisNotation → EllipsisNotationStaticArrayInterfaceExt
```

All Core test files pass:

```
======== RUN basic.jl ========          (passes)
CartesianIndex          | 6  / 6
StaticArrayInterface    | 10 / 10
Allocation Tests        | 4  / 4
ALL_CORE_TESTS_COMPLETED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)