### PR TITLE
Bump version to 1.10.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EllipsisNotation"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.10.1"
+version = "1.10.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.10.1 -> 1.10.2) to release unreleased commits on `master` via JuliaRegistrator.