### PR TITLE
Update SciMLTesting QA compat to 2.1

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ EllipsisNotation = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Set test/qa SciMLTesting compat to exactly 2.1.

## Validation
- `timeout 3600 julia --project=test/qa --startup-file=no -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`\n- TOML parse check for `test/qa/Project.toml`\n- `git diff --check`\n- No changed Julia files for Runic\n- grep for `api_docs = false`, `docstrings_broken`, `missing_docstrings`, `Base.Docs` patterns