### PR TITLE
Release prep: bump EllipsisNotation to 1.10.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EllipsisNotation"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.10.2"
+version = "1.10.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 1.10.2 (no source or runtime-dependency changes).