### PR TITLE
Check rendered public API docs

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,8 +3,6 @@ using JET
 
 run_qa(
     EllipsisNotation;
-    api_docs_kwargs = (; rendered = true),
-    explicit_imports = true,
     ei_kwargs = (;
         # `tail` is a `Base` internal on Julia 1.10 (it is declared public only on
         # 1.11+); it is imported here for the `to_indices` / `_ndims_index` machinery.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,7 @@ using JET
 
 run_qa(
     EllipsisNotation;
+    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     ei_kwargs = (;
         # `tail` is a `Base` internal on Julia 1.10 (it is declared public only on


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs coverage in QA

The package-owned exported API is `..`; it already has a source docstring and is rendered by the existing Documenter `@autodocs` page.

## Validation
- `git diff --check`
- `julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` -> Quality Assurance 18/18
- `julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` -> docs rendered, local deploy warning only
- `julia +1.10 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` -> tests passed; Core alloc/basic/cartesian/more_generic/static_array_interface all green
- Runic v1.7.0 `--check src test docs`
