### PR TITLE
QA: assert the StaticArrayInterface extension actually loaded

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,6 +5,12 @@ using JET
 # so load the weakdeps here to get EllipsisNotationStaticArrayInterfaceExt scanned.
 using StaticArrayInterface
 
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(EllipsisNotation, :EllipsisNotationStaticArrayInterfaceExt) !== nothing
+end
+
 run_qa(EllipsisNotation)
 
 @testset "JET type stability" begin


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

Follow-up to #129, which was merged before this could be added to it.

## Why

#129 made QA scan `EllipsisNotationStaticArrayInterfaceExt` by loading its trigger in
`test/qa/qa.jl`. That fix has a silent-failure mode: ExplicitImports **skips** an
extension whose module does not exist — `Base.get_extension` returns `nothing` and every
check reports a clean pass. So if a later change breaks the extension's precompilation,
or a trigger drops out of the QA environment, QA stays green while extension coverage
silently drops back to zero.

This adds an assertion that the extension module actually exists, so coverage is proven
rather than assumed:

```julia
@testset "Extensions loaded" begin
    @test Base.get_extension(EllipsisNotation, :EllipsisNotationStaticArrayInterfaceExt) !== nothing
end
```

Negative control checked locally — the assertion really does discriminate:

```
without trigger loaded: nothing
with trigger loaded:    EllipsisNotationStaticArrayInterfaceExt
```

## Local result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch (rebased on the
merged #129):

```
Test Summary: | Pass  Total     Time
QA/qa.jl      |   35     35  1m23.1s
     Testing EllipsisNotation tests passed
```

34 before, 35 with the guard.
